### PR TITLE
Fix ban sync module + add option to sync to role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,5 @@ hs_err_pid*
 !gradle-wrapper.jar
 
 # run-* Gradle tasks
-**/loader/run/
-**/velocity/run/
+**/loader/run
+**/velocity/run

--- a/bukkit/src/main/java/com/discordsrv/bukkit/BukkitDiscordSRVImpl.java
+++ b/bukkit/src/main/java/com/discordsrv/bukkit/BukkitDiscordSRVImpl.java
@@ -18,6 +18,8 @@
 
 package com.discordsrv.bukkit;
 
+import com.discordsrv.bukkit.ban.BukkitBanModule;
+import com.discordsrv.bukkit.ban.PaperBanModule;
 import com.discordsrv.bukkit.command.game.BukkitGameCommandExecutionHelper;
 import com.discordsrv.bukkit.command.game.PaperGameCommandExecutionHelper;
 import com.discordsrv.bukkit.command.game.handler.BukkitBasicCommandHandler;
@@ -119,6 +121,7 @@ public class BukkitDiscordSRVImpl extends BukkitDiscordSRV {
             registerModule(PaperDeathListener::new);
             registerModule(PaperJoinListener::new);
             registerModule(PaperQuitListener::new);
+            registerModule(PaperBanModule::new);
         } else {
             // Legacy
             registerModule(BukkitChatListener::new);
@@ -126,6 +129,7 @@ public class BukkitDiscordSRVImpl extends BukkitDiscordSRV {
             registerModule(BukkitDeathListener::new);
             registerModule(BukkitJoinListener::new);
             registerModule(BukkitQuitListener::new);
+            registerModule(BukkitBanModule::new);
         }
     }
 

--- a/common/src/main/java/com/discordsrv/common/abstraction/sync/enums/BanSyncAction.java
+++ b/common/src/main/java/com/discordsrv/common/abstraction/sync/enums/BanSyncAction.java
@@ -16,39 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.discordsrv.common.feature.bansync.enums;
+package com.discordsrv.common.abstraction.sync.enums;
 
-import com.discordsrv.common.abstraction.sync.result.ISyncResult;
-
-public enum BanSyncResult implements ISyncResult {
-
-    // Error
-    NO_PUNISHMENT_INTEGRATION("No punishment integration"),
-    NO_DISCORD_CONNECTION("No Discord connection"),
-    GUILD_DOESNT_EXIST("Guild doesn't exist"),
-    INVALID_CONFIG("Invalid config"),
-    NOT_A_GUILD_MEMBER("User is not part of the server the role is in"),
-
-    ;
-
-    private final String format;
-
-    BanSyncResult(String format) {
-        this.format = format;
-    }
-
-    @Override
-    public boolean isError() {
-        return true;
-    }
-
-    @Override
-    public boolean isUpdate() {
-        return false;
-    }
-
-    @Override
-    public String getFormat() {
-        return format;
-    }
+public enum BanSyncAction {
+    BAN,
+    ROLE
 }

--- a/common/src/main/java/com/discordsrv/common/config/main/BanSyncConfig.java
+++ b/common/src/main/java/com/discordsrv/common/config/main/BanSyncConfig.java
@@ -18,6 +18,9 @@
 
 package com.discordsrv.common.config.main;
 
+import com.discordsrv.common.abstraction.sync.enums.BanSyncAction;
+import com.discordsrv.common.config.configurate.annotation.Constants;
+import com.discordsrv.common.config.configurate.annotation.Order;
 import com.discordsrv.common.config.main.generic.AbstractSyncConfig;
 import com.discordsrv.common.feature.bansync.BanSyncModule;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
@@ -27,25 +30,14 @@ import org.spongepowered.configurate.objectmapping.meta.Comment;
 public class BanSyncConfig extends AbstractSyncConfig<BanSyncConfig, BanSyncModule.Game, Long> {
 
     @Comment("The id for the Discord server where the bans should be synced from/to")
+    @Order(-10)
     public long serverId = 0L;
 
-    @Comment("The reason applied when creating new bans in Minecraft")
-    public String gameBanReasonFormat = "%punishment_reason%";
+    @Comment("Options for syncing bans from Minecraft to Discord")
+    public MinecraftToDiscordConfig minecraftToDiscord = new MinecraftToDiscordConfig();
 
-    @Comment("The punisher applied when creating new bans in Minecraft")
-    public String gamePunisherFormat = "%user_color%@%user_name%";
-
-    @Comment("The kick reason when a ban is applied to a online player")
-    public String gameKickReason = "&cYou have been banned for &f%punishment_reason% &cby &f%punishment_punisher%";
-
-    @Comment("The reason applied when creating new bans in Discord")
-    public String discordBanReasonFormat = "Banned by %punishment_punisher% in Minecraft for %punishment_reason%, ends: %punishment_until:'YYYY-MM-dd HH:mm:ss zzz'|text:'Never'%";
-
-    @Comment("The reason applied when removing bans in Discord")
-    public String discordUnbanReasonFormat = "Unbanned in Minecraft";
-
-    @Comment("The amount of hours to delete Discord messages, when syncing bans from Minecraft to Discord")
-    public int discordMessageHoursToDelete = 0;
+    @Comment("Options for syncing bans from Discord to Minecraft")
+    public DiscordToMinecraftConfig discordToMinecraft = new DiscordToMinecraftConfig();
 
     @Comment("Resync upon linking")
     public boolean resyncUponLinking = true;
@@ -73,5 +65,53 @@ public class BanSyncConfig extends AbstractSyncConfig<BanSyncConfig, BanSyncModu
     @Override
     public String describe() {
         return Long.toUnsignedString(serverId);
+    }
+
+    @ConfigSerializable
+    public static class DiscordToMinecraftConfig {
+
+        @Comment("The reason applied when creating new bans in Minecraft")
+        public String banReasonFormat = "%punishment_reason%";
+
+        @Comment("The punisher applied when creating new bans in Minecraft")
+        public String punisherFormat = "%user_color%@%user_name%";
+
+        @Comment("The kick reason when a ban is applied to a online player")
+        public String kickReason = "&cYou have been banned for &f%punishment_reason% &cby &f%punishment_punisher%";
+    }
+
+    @ConfigSerializable
+    public static class MinecraftToDiscordConfig {
+
+        @Comment("What action(s) to perform on the linked Discord account when a player is banned in Minecraft. Can be configured in more detail below\n"
+                + "Valid options: %1, %2")
+        @Constants.Comment({"ban", "role"})
+        public BanSyncAction action = BanSyncAction.BAN;
+
+        @Comment("Config for banning users on Discord when they are banned in Minecraft")
+        public BanConfig ban = new BanConfig();
+
+        @Comment("Config for adding a Discord role to users when they are banned in Minecraft")
+        public RoleConfig role = new RoleConfig();
+
+        @ConfigSerializable
+        public static class BanConfig {
+
+            @Comment("The reason applied when creating new bans in Discord")
+            public String banReasonFormat = "Banned by %punishment_punisher% in Minecraft for %punishment_reason%, ends: %punishment_until:'YYYY-MM-dd HH:mm:ss zzz'|text:'Never'%";
+
+            @Comment("The reason applied when removing bans in Discord")
+            public String unbanReasonFormat = "Unbanned in Minecraft";
+
+            @Comment("The amount of hours to delete Discord messages, when syncing bans from Minecraft to Discord")
+            public int messageHoursToDelete = 0;
+        }
+
+        @ConfigSerializable
+        public static class RoleConfig {
+
+            @Comment("Discord role id to add to the user when they are banned in Minecraft.")
+            public Long roleId = 0L;
+        }
     }
 }

--- a/common/src/main/java/com/discordsrv/common/config/main/generic/AbstractSyncConfig.java
+++ b/common/src/main/java/com/discordsrv/common/config/main/generic/AbstractSyncConfig.java
@@ -22,6 +22,7 @@ import com.discordsrv.common.DiscordSRV;
 import com.discordsrv.common.abstraction.sync.enums.SyncDirection;
 import com.discordsrv.common.abstraction.sync.enums.SyncSide;
 import com.discordsrv.common.config.configurate.annotation.Constants;
+import com.discordsrv.common.config.configurate.annotation.Order;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 import org.spongepowered.configurate.objectmapping.meta.Comment;
 
@@ -39,6 +40,7 @@ public abstract class AbstractSyncConfig<C extends AbstractSyncConfig<C, G, D>, 
     @Comment("The direction to synchronize in.\n"
             + "Valid options: %1, %2, %3")
     @Constants.Comment({"bidirectional", "minecraft_to_discord", "discord_to_minecraft"})
+    @Order(-5)
     public SyncDirection direction = SyncDirection.BIDIRECTIONAL;
 
     @Comment("Timed resynchronization")


### PR DESCRIPTION
- Fixed Paper/Bukkit ban listeners
- Fixed NPE causing resync to silently fail
- Made .gitignore properly ignore the files generated by runServer (for me at least)
- Rearranged ban sync config
- Added option to add a role when a player is banned

There still needs to be a solution to detect unbans/bans of offline players but this will likely require a bit of a refactor so some thinking is required and I'm just going to put it on the project board for now.