### PR TITLE
Pester about linking accounts

### DIFF
--- a/common/src/main/java/com/discordsrv/common/AbstractDiscordSRV.java
+++ b/common/src/main/java/com/discordsrv/common/AbstractDiscordSRV.java
@@ -89,6 +89,7 @@ import com.discordsrv.common.feature.customcommands.CustomCommandModule;
 import com.discordsrv.common.feature.groupsync.GroupSyncModule;
 import com.discordsrv.common.feature.linking.LinkProvider;
 import com.discordsrv.common.feature.linking.LinkedRoleModule;
+import com.discordsrv.common.feature.linking.LinkPesteringModule;
 import com.discordsrv.common.feature.linking.LinkingModule;
 import com.discordsrv.common.feature.linking.LinkingRewardsModule;
 import com.discordsrv.common.feature.linking.impl.MinecraftAuthenticationLinker;
@@ -749,6 +750,7 @@ public abstract class AbstractDiscordSRV<
         registerModule(WorldChannelModule::new);
         registerModule(MentionCachingModule::new);
         registerModule(LinkingModule::new);
+        registerModule(LinkPesteringModule::new);
         registerModule(PresenceUpdaterModule::new);
         registerModule(MentionGameRenderingModule::new);
         registerModule(CustomCommandModule::new);

--- a/common/src/main/java/com/discordsrv/common/abstraction/module/AbstractTimedTrackingModule.java
+++ b/common/src/main/java/com/discordsrv/common/abstraction/module/AbstractTimedTrackingModule.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of DiscordSRV, licensed under the GPLv3 License
+ * Copyright (c) 2016-2026 Austin "Scarsz" Shapiro, Henri "Vankka" Schubin and DiscordSRV contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.discordsrv.common.abstraction.module;
+
+import com.discordsrv.api.reload.ReloadResult;
+import com.discordsrv.common.DiscordSRV;
+import com.discordsrv.common.core.logging.NamedLogger;
+import com.discordsrv.common.core.module.type.AbstractModule;
+
+import java.time.Duration;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+
+/**
+ * Base module abstraction for features that run a single repeating timed task.
+ *
+ * <p>Current behavior:</p>
+ * <ul>
+ *   <li>On {@link #enable()}, runs {@link #onTimedEnable()} and then (re)starts the timed task.</li>
+ *   <li>On {@link #reload(Consumer)}, only restarts the timed task (does not call enable/disable hooks).</li>
+ *   <li>On {@link #disable()}, cancels the timed task and then runs {@link #onTimedDisable()}.</li>
+ *   <li>Only one scheduled future is tracked at a time; restarting always cancels the previous one first.</li>
+ * </ul>
+ */
+public abstract class AbstractTimedTrackingModule extends AbstractModule<DiscordSRV> {
+
+    /**
+     * The currently active scheduled repeating task, or {@code null} when not scheduled.
+     */
+    private Future<?> timedFuture;
+
+    protected AbstractTimedTrackingModule(DiscordSRV discordSRV, String loggerName) {
+        super(discordSRV, new NamedLogger(discordSRV, loggerName));
+    }
+
+    @Override
+    public void enable() {
+        restartTimedTask();
+    }
+
+    @Override
+    public void reload(Consumer<ReloadResult> resultConsumer) {
+        restartTimedTask();
+    }
+
+    @Override
+    public void disable() {
+        stopTimedTask();
+    }
+
+    protected final void restartTimedTask() {
+        stopTimedTask();
+
+        if (!shouldRunTimedTask()) {
+            return;
+        }
+
+        Duration interval = timedTaskInterval();
+        if (interval.isNegative() || interval.isZero()) {
+            interval = Duration.ofSeconds(1);
+        }
+
+        // Schedules fixed-rate execution with initial delay equal to the configured interval.
+        timedFuture = discordSRV.scheduler().runAtFixedRate(this::runTimedTask, interval);
+    }
+
+    protected final void stopTimedTask() {
+        if (timedFuture != null) {
+            timedFuture.cancel(true);
+            timedFuture = null;
+        }
+    }
+
+    protected void onTimedEnable() {}
+
+    protected void onTimedDisable() {}
+
+    /**
+     * Determines whether the timed task should be scheduled at this moment.
+     *
+     * @return true to schedule; false to skip scheduling
+     */
+    protected abstract boolean shouldRunTimedTask();
+
+    protected abstract Duration timedTaskInterval();
+
+    /**
+     * Timed task invoked by the scheduler on each interval.
+     */
+    protected abstract void runTimedTask();
+}

--- a/common/src/main/java/com/discordsrv/common/abstraction/module/AbstractTimedTrackingModule.java
+++ b/common/src/main/java/com/discordsrv/common/abstraction/module/AbstractTimedTrackingModule.java
@@ -22,6 +22,7 @@ import com.discordsrv.api.reload.ReloadResult;
 import com.discordsrv.common.DiscordSRV;
 import com.discordsrv.common.core.logging.NamedLogger;
 import com.discordsrv.common.core.module.type.AbstractModule;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.time.Duration;
 import java.util.concurrent.Future;
@@ -71,9 +72,21 @@ public abstract class AbstractTimedTrackingModule extends AbstractModule<Discord
             return;
         }
 
+        if (getMaximumInterval() != null && getMaximumInterval().compareTo(getMinimalInterval()) < 0) {
+            throw new IllegalStateException("Maximum timed task interval must be greater than or equal to the minimum interval, got: " + getMaximumInterval() + " < " + getMinimalInterval());
+        }
+
+        if (getMinimalInterval().isNegative() || getMinimalInterval().isZero()) {
+            throw new IllegalStateException("Minimum timed task interval must be positive, got: " + getMinimalInterval());
+        }
+
         Duration interval = timedTaskInterval();
-        if (interval.isNegative() || interval.isZero()) {
-            interval = Duration.ofSeconds(1);
+        if (getMinimalInterval().compareTo(interval) < 0) {
+            interval = getMinimalInterval();
+            discordSRV.logger().trace("Timed task interval is below the minimum, adjusting to minimum: " + getMinimalInterval());
+        } else if (getMaximumInterval() != null && getMaximumInterval().compareTo(interval) < 0) {
+            interval = getMaximumInterval();
+            discordSRV.logger().trace("Timed task interval is above the maximum, adjusting to maximum: " + getMaximumInterval());
         }
 
         // Schedules fixed-rate execution with initial delay equal to the configured interval.
@@ -98,6 +111,29 @@ public abstract class AbstractTimedTrackingModule extends AbstractModule<Discord
      */
     protected abstract boolean shouldRunTimedTask();
 
+    /**
+     * Gets the minimum allowed interval for the timed task.
+     * This will be used as a lower bound for timedTaskInterval().
+     *
+     * @throws IllegalStateException if the returned interval is not positive or if it's higher than getMaximumInterval().
+     */
+    protected abstract Duration getMinimalInterval();
+
+    /**
+     * Gets the maximal allowed interval for the timer task.
+     * This will be used as an upper bound for timedTaskInterval().
+     * If it returns null it will be treated as if there's no upper bound.
+     *
+     * @throws IllegalStateException if the returned interval is not positive (unless it's null) or if it's lower than getMinimalInterval().
+     */
+    protected Duration getMaximumInterval() {
+        return null;
+    }
+
+    /**
+     * Gets the user defined interval for the timed task.
+     * If the interval is out of bounds with regard to getMinimalInterval() and getMaximumInterval(), it will be adjusted to fit within those bounds.
+     */
     protected abstract Duration timedTaskInterval();
 
     /**

--- a/common/src/main/java/com/discordsrv/common/abstraction/module/AbstractTimedTrackingModule.java
+++ b/common/src/main/java/com/discordsrv/common/abstraction/module/AbstractTimedTrackingModule.java
@@ -22,7 +22,6 @@ import com.discordsrv.api.reload.ReloadResult;
 import com.discordsrv.common.DiscordSRV;
 import com.discordsrv.common.core.logging.NamedLogger;
 import com.discordsrv.common.core.module.type.AbstractModule;
-import org.jetbrains.annotations.ApiStatus;
 
 import java.time.Duration;
 import java.util.concurrent.Future;
@@ -46,8 +45,8 @@ public abstract class AbstractTimedTrackingModule extends AbstractModule<Discord
      */
     private Future<?> timedFuture;
 
-    protected AbstractTimedTrackingModule(DiscordSRV discordSRV, String loggerName) {
-        super(discordSRV, new NamedLogger(discordSRV, loggerName));
+    protected AbstractTimedTrackingModule(DiscordSRV discordSRV, NamedLogger logger) {
+        super(discordSRV, logger);
     }
 
     @Override
@@ -72,21 +71,21 @@ public abstract class AbstractTimedTrackingModule extends AbstractModule<Discord
             return;
         }
 
-        if (getMaximumInterval() != null && getMaximumInterval().compareTo(getMinimalInterval()) < 0) {
-            throw new IllegalStateException("Maximum timed task interval must be greater than or equal to the minimum interval, got: " + getMaximumInterval() + " < " + getMinimalInterval());
+        if (getMaximumInterval() != null && getMaximumInterval().compareTo(getMinimumInterval()) < 0) {
+            throw new IllegalStateException("Maximum timed task interval must be greater than or equal to the minimum interval, got: " + getMaximumInterval() + " < " + getMinimumInterval());
         }
 
-        if (getMinimalInterval().isNegative() || getMinimalInterval().isZero()) {
-            throw new IllegalStateException("Minimum timed task interval must be positive, got: " + getMinimalInterval());
+        if (getMinimumInterval().isNegative() || getMinimumInterval().isZero()) {
+            throw new IllegalStateException("Minimum timed task interval must be positive, got: " + getMinimumInterval());
         }
 
         Duration interval = timedTaskInterval();
-        if (getMinimalInterval().compareTo(interval) < 0) {
-            interval = getMinimalInterval();
-            discordSRV.logger().trace("Timed task interval is below the minimum, adjusting to minimum: " + getMinimalInterval());
+        if (getMinimumInterval().compareTo(interval) < 0) {
+            interval = getMinimumInterval();
+            discordSRV.logger().debug("Timed task interval is below the minimum, adjusting to minimum: " + getMinimumInterval());
         } else if (getMaximumInterval() != null && getMaximumInterval().compareTo(interval) < 0) {
             interval = getMaximumInterval();
-            discordSRV.logger().trace("Timed task interval is above the maximum, adjusting to maximum: " + getMaximumInterval());
+            discordSRV.logger().debug("Timed task interval is above the maximum, adjusting to maximum: " + getMaximumInterval());
         }
 
         // Schedules fixed-rate execution with initial delay equal to the configured interval.
@@ -113,18 +112,18 @@ public abstract class AbstractTimedTrackingModule extends AbstractModule<Discord
 
     /**
      * Gets the minimum allowed interval for the timed task.
-     * This will be used as a lower bound for timedTaskInterval().
+     * This will be used as a lower bound for {@link #timedTaskInterval()}.
      *
-     * @throws IllegalStateException if the returned interval is not positive or if it's higher than getMaximumInterval().
+     * @throws IllegalStateException if the returned interval is not positive or if it's higher than {@link #getMaximumInterval()}.
      */
-    protected abstract Duration getMinimalInterval();
+    protected abstract Duration getMinimumInterval();
 
     /**
      * Gets the maximal allowed interval for the timer task.
-     * This will be used as an upper bound for timedTaskInterval().
+     * This will be used as an upper bound for {@link #timedTaskInterval()}.
      * If it returns null it will be treated as if there's no upper bound.
      *
-     * @throws IllegalStateException if the returned interval is not positive (unless it's null) or if it's lower than getMinimalInterval().
+     * @throws IllegalStateException if the returned interval is not positive (unless it's null) or if it's lower than {@link #getMinimumInterval()}.
      */
     protected Duration getMaximumInterval() {
         return null;
@@ -132,7 +131,7 @@ public abstract class AbstractTimedTrackingModule extends AbstractModule<Discord
 
     /**
      * Gets the user defined interval for the timed task.
-     * If the interval is out of bounds with regard to getMinimalInterval() and getMaximumInterval(), it will be adjusted to fit within those bounds.
+     * If the interval is out of bounds with regard to {@link #getMinimumInterval()} and {@link #getMaximumInterval()}, it will be adjusted to fit within those bounds.
      */
     protected abstract Duration timedTaskInterval();
 

--- a/common/src/main/java/com/discordsrv/common/abstraction/module/AbstractTimedTrackingModule.java
+++ b/common/src/main/java/com/discordsrv/common/abstraction/module/AbstractTimedTrackingModule.java
@@ -22,6 +22,7 @@ import com.discordsrv.api.reload.ReloadResult;
 import com.discordsrv.common.DiscordSRV;
 import com.discordsrv.common.core.logging.NamedLogger;
 import com.discordsrv.common.core.module.type.AbstractModule;
+import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
 import java.util.concurrent.Future;
@@ -71,19 +72,19 @@ public abstract class AbstractTimedTrackingModule extends AbstractModule<Discord
             return;
         }
 
-        if (getMaximumInterval() != null && getMaximumInterval().compareTo(getMinimumInterval()) < 0) {
+        if (getMaximumInterval() != null && getMaximumInterval().minus(getMinimumInterval()).toMillis() < 0) {
             throw new IllegalStateException("Maximum timed task interval must be greater than or equal to the minimum interval, got: " + getMaximumInterval() + " < " + getMinimumInterval());
         }
 
-        if (getMinimumInterval().isNegative() || getMinimumInterval().isZero()) {
+        if (getMinimumInterval().toMillis() <= 0) {
             throw new IllegalStateException("Minimum timed task interval must be positive, got: " + getMinimumInterval());
         }
 
         Duration interval = timedTaskInterval();
-        if (getMinimumInterval().compareTo(interval) < 0) {
+        if (interval.minus(getMinimumInterval()).toMillis() < 0) {
             interval = getMinimumInterval();
             discordSRV.logger().debug("Timed task interval is below the minimum, adjusting to minimum: " + getMinimumInterval());
-        } else if (getMaximumInterval() != null && getMaximumInterval().compareTo(interval) < 0) {
+        } else if (getMaximumInterval() != null && interval.minus(getMaximumInterval()).toMillis() > 0) {
             interval = getMaximumInterval();
             discordSRV.logger().debug("Timed task interval is above the maximum, adjusting to maximum: " + getMaximumInterval());
         }
@@ -133,6 +134,7 @@ public abstract class AbstractTimedTrackingModule extends AbstractModule<Discord
      * Gets the user defined interval for the timed task.
      * If the interval is out of bounds with regard to {@link #getMinimumInterval()} and {@link #getMaximumInterval()}, it will be adjusted to fit within those bounds.
      */
+    @NotNull
     protected abstract Duration timedTaskInterval();
 
     /**

--- a/common/src/main/java/com/discordsrv/common/command/game/GameCommandModule.java
+++ b/common/src/main/java/com/discordsrv/common/command/game/GameCommandModule.java
@@ -18,6 +18,8 @@
 
 package com.discordsrv.common.command.game;
 
+import com.discordsrv.api.placeholder.annotation.Placeholder;
+import com.discordsrv.api.placeholder.annotation.PlaceholderPrefix;
 import com.discordsrv.api.reload.ReloadResult;
 import com.discordsrv.common.DiscordSRV;
 import com.discordsrv.common.command.combined.commands.LinkOtherCommand;
@@ -31,12 +33,23 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
+@PlaceholderPrefix("gamecommand_")
 public class GameCommandModule extends AbstractModule<com.discordsrv.common.DiscordSRV> {
 
     private final Set<GameCommand> commands = new HashSet<>();
 
     public GameCommandModule(DiscordSRV discordSRV) {
         super(discordSRV);
+    }
+
+    @Override
+    public void enable() {
+        discordSRV.placeholderService().addGlobalContext(this);
+    }
+
+    @Override
+    public void disable() {
+        discordSRV.placeholderService().removeGlobalContext(this);
     }
 
     @Override
@@ -79,5 +92,18 @@ public class GameCommandModule extends AbstractModule<com.discordsrv.common.Disc
         }
 
         handler.registerCommand(command);
+    }
+
+    @Placeholder("discord_link_alias")
+    public String discordLinkAlias() {
+        GameCommandConfig config = discordSRV.config() != null ? discordSRV.config().gameCommand : null;
+        if (config == null) {
+            return "";
+        }
+
+        if (config.useLinkAlias) return "link";
+        if (config.useDiscordCommand) return "discord link";
+
+        return "discordsrv link";
     }
 }

--- a/common/src/main/java/com/discordsrv/common/config/main/linking/LinkedAccountConfig.java
+++ b/common/src/main/java/com/discordsrv/common/config/main/linking/LinkedAccountConfig.java
@@ -58,8 +58,8 @@ public class LinkedAccountConfig {
         @Constants.Comment({"join", "timer", "both"})
         public PesteringMode mode = PesteringMode.JOIN;
 
-        @Comment("How often (in seconds) should we send the timed pestering message to users who have not linked their accounts. Minimum of 10 seconds")
-        public int timer = 300;
+        @Comment("How often (in minutes) should we send the timed pestering message to users who have not linked their accounts. Minimum of 1 minute")
+        public int timer = 1;
 
         public enum PesteringMode {
             JOIN,

--- a/common/src/main/java/com/discordsrv/common/config/main/linking/LinkedAccountConfig.java
+++ b/common/src/main/java/com/discordsrv/common/config/main/linking/LinkedAccountConfig.java
@@ -56,15 +56,15 @@ public class LinkedAccountConfig {
                 + " \"%2\" to send a timed message \n"
                 + " \"%3\" to do both of the above")
         @Constants.Comment({"join", "timer", "both"})
-        public PesteringMode mode = PesteringMode.Join;
+        public PesteringMode mode = PesteringMode.JOIN;
 
         @Comment("How often (in seconds) should we send the timed pestering message to users who have not linked their accounts. Minimum of 10 seconds")
         public int timer = 300;
 
         public enum PesteringMode {
-            Join,
-            Timer,
-            Both
+            JOIN,
+            TIMER,
+            BOTH
         }
     }
 }

--- a/common/src/main/java/com/discordsrv/common/config/main/linking/LinkedAccountConfig.java
+++ b/common/src/main/java/com/discordsrv/common/config/main/linking/LinkedAccountConfig.java
@@ -29,6 +29,9 @@ public class LinkedAccountConfig {
     @Comment("Should linked accounts be enabled")
     public boolean enabled = true;
 
+    @Comment("Should users who have not linked their accounts be sent a message encouraging them to link their accounts every time they join the server")
+    public LinkPesteringConfig pesteringConfig = new LinkPesteringConfig();
+
     @Comment("The linked account provider\n"
             + "\n"
             + " - auto: Uses \"minecraftauth\" if the %1 permits it and the server is in online mode or using ip forwarding, otherwise \"%3\"\n"
@@ -41,5 +44,27 @@ public class LinkedAccountConfig {
         AUTO,
         MINECRAFTAUTH,
         STORAGE
+    }
+
+    public static class LinkPesteringConfig {
+        @Comment("Should link pestering be enabled")
+        public boolean enabled = true;
+
+        @Comment("How should we pester users to link their accounts\n"
+                + "\n"
+                + " \"%1\" to send a message when they connect to the server\n"
+                + " \"%2\" to send a timed message \n"
+                + " \"%3\" to do both of the above")
+        @Constants.Comment({"join", "timer", "both"})
+        public PesteringMode mode = PesteringMode.Join;
+
+        @Comment("How often (in seconds) should we send the timed pestering message to users who have not linked their accounts. Minimum of 10 seconds")
+        public int timer = 300;
+
+        public enum PesteringMode {
+            Join,
+            Timer,
+            Both
+        }
     }
 }

--- a/common/src/main/java/com/discordsrv/common/config/messages/MessagesConfig.java
+++ b/common/src/main/java/com/discordsrv/common/config/messages/MessagesConfig.java
@@ -144,7 +144,7 @@ public class MessagesConfig implements Config {
 
     // Pester to players who haven't linked their accounts yet.
     public MinecraftMessage playerLinkPestering = minecraft(
-            "You have not linked your account yet. Please run /%gamecommand_discord_link_alias% to get started."
+            "You have not linked your Discord account yet. Please run /%gamecommand_discord_link_alias% to get started."
     );
 
     // DiscordSRV command

--- a/common/src/main/java/com/discordsrv/common/config/messages/MessagesConfig.java
+++ b/common/src/main/java/com/discordsrv/common/config/messages/MessagesConfig.java
@@ -142,6 +142,11 @@ public class MessagesConfig implements Config {
             "Discord user"
     );
 
+    // Pester to players who haven't linked their accounts yet.
+    public MinecraftMessage playerLinkPestering = minecraft(
+            "You have not linked your account yet. Please run /%gamecommand_discord_link_alias% to get started."
+    );
+
     // DiscordSRV command
 
     public DiscordMessage discordsrvCommandDescription = discord(

--- a/common/src/main/java/com/discordsrv/common/feature/linking/LinkPesteringModule.java
+++ b/common/src/main/java/com/discordsrv/common/feature/linking/LinkPesteringModule.java
@@ -53,6 +53,11 @@ public class LinkPesteringModule extends AbstractTimedTrackingModule {
     }
 
     @Override
+    protected Duration getMinimalInterval() {
+        return Duration.ofSeconds(10);
+    }
+
+    @Override
     protected Duration timedTaskInterval() {
         int intervalSeconds = Math.max(discordSRV.config().linkedAccounts.pesteringConfig.timer, 10);
         return Duration.ofSeconds(intervalSeconds);

--- a/common/src/main/java/com/discordsrv/common/feature/linking/LinkPesteringModule.java
+++ b/common/src/main/java/com/discordsrv/common/feature/linking/LinkPesteringModule.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of DiscordSRV, licensed under the GPLv3 License
+ * Copyright (c) 2016-2026 Austin "Scarsz" Shapiro, Henri "Vankka" Schubin and DiscordSRV contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.discordsrv.common.feature.linking;
+
+import com.discordsrv.api.eventbus.Subscribe;
+import com.discordsrv.common.DiscordSRV;
+import com.discordsrv.common.abstraction.player.IPlayer;
+import com.discordsrv.common.config.main.linking.LinkedAccountConfig;
+import com.discordsrv.common.events.player.PlayerConnectedEvent;
+import com.discordsrv.common.abstraction.module.AbstractTimedTrackingModule;
+
+import java.time.Duration;
+import java.util.UUID;
+
+public class LinkPesteringModule extends AbstractTimedTrackingModule {
+
+    public LinkPesteringModule(DiscordSRV discordSRV) {
+        super(discordSRV, "LINK_PESTER");
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return discordSRV.config().linkedAccounts.pesteringConfig.enabled;
+    }
+
+    @Subscribe
+    public void onPlayerConnected(PlayerConnectedEvent event) {
+        if (discordSRV.config().linkedAccounts.pesteringConfig.mode == LinkedAccountConfig.LinkPesteringConfig.PesteringMode.Timer) {
+            return;
+        }
+        pesterIfUnlinked(event.player());
+    }
+
+    @Override
+    protected boolean shouldRunTimedTask() {
+        return discordSRV.config().linkedAccounts.pesteringConfig.mode != LinkedAccountConfig.LinkPesteringConfig.PesteringMode.Join;
+    }
+
+    @Override
+    protected Duration timedTaskInterval() {
+        int intervalSeconds = Math.max(discordSRV.config().linkedAccounts.pesteringConfig.timer, 10);
+        return Duration.ofSeconds(intervalSeconds);
+    }
+
+    @Override
+    protected void runTimedTask() {
+        pesterOnlinePlayers();
+    }
+
+    private void pesterOnlinePlayers() {
+        for (IPlayer player : discordSRV.playerProvider().allPlayers()) {
+            pesterIfUnlinked(player);
+        }
+    }
+
+    private void pesterIfUnlinked(IPlayer player) {
+        LinkProvider linkProvider = discordSRV.linkProvider();
+        if (linkProvider == null) {
+            return;
+        }
+
+        UUID playerUUID = player.uniqueId();
+        linkProvider.get(playerUUID)
+                .whenSuccessful(link -> {
+                    if (link.isPresent()) {
+                        return;
+                    }
+
+                    IPlayer onlinePlayer = discordSRV.playerProvider().player(playerUUID);
+                    if (onlinePlayer == null) {
+                        return;
+                    }
+
+                    onlinePlayer.sendMessage(discordSRV.messagesConfig().playerLinkPestering.asComponent());
+                })
+                .whenFailed(t -> logger().debug("Failed to pester unlinked player " + playerUUID, t));
+    }
+}

--- a/common/src/main/java/com/discordsrv/common/feature/linking/LinkPesteringModule.java
+++ b/common/src/main/java/com/discordsrv/common/feature/linking/LinkPesteringModule.java
@@ -41,7 +41,7 @@ public class LinkPesteringModule extends AbstractTimedTrackingModule {
 
     @Subscribe
     public void onPlayerConnected(PlayerConnectedEvent event) {
-        if (discordSRV.config().linkedAccounts.pesteringConfig.mode == LinkedAccountConfig.LinkPesteringConfig.PesteringMode.Timer) {
+        if (discordSRV.config().linkedAccounts.pesteringConfig.mode == LinkedAccountConfig.LinkPesteringConfig.PesteringMode.TIMER) {
             return;
         }
         pesterIfUnlinked(event.player());
@@ -49,7 +49,7 @@ public class LinkPesteringModule extends AbstractTimedTrackingModule {
 
     @Override
     protected boolean shouldRunTimedTask() {
-        return discordSRV.config().linkedAccounts.pesteringConfig.mode != LinkedAccountConfig.LinkPesteringConfig.PesteringMode.Join;
+        return discordSRV.config().linkedAccounts.pesteringConfig.mode != LinkedAccountConfig.LinkPesteringConfig.PesteringMode.JOIN;
     }
 
     @Override

--- a/common/src/main/java/com/discordsrv/common/feature/linking/LinkPesteringModule.java
+++ b/common/src/main/java/com/discordsrv/common/feature/linking/LinkPesteringModule.java
@@ -25,6 +25,7 @@ import com.discordsrv.common.config.main.linking.LinkedAccountConfig;
 import com.discordsrv.common.core.logging.NamedLogger;
 import com.discordsrv.common.events.player.PlayerConnectedEvent;
 import com.discordsrv.common.abstraction.module.AbstractTimedTrackingModule;
+import org.jspecify.annotations.NonNull;
 
 import java.time.Duration;
 import java.util.UUID;
@@ -59,7 +60,7 @@ public class LinkPesteringModule extends AbstractTimedTrackingModule {
     }
 
     @Override
-    protected Duration timedTaskInterval() {
+    protected @NonNull Duration timedTaskInterval() {
         return Duration.ofMinutes(discordSRV.config().linkedAccounts.pesteringConfig.timer);
     }
 

--- a/common/src/main/java/com/discordsrv/common/feature/linking/LinkPesteringModule.java
+++ b/common/src/main/java/com/discordsrv/common/feature/linking/LinkPesteringModule.java
@@ -22,6 +22,7 @@ import com.discordsrv.api.eventbus.Subscribe;
 import com.discordsrv.common.DiscordSRV;
 import com.discordsrv.common.abstraction.player.IPlayer;
 import com.discordsrv.common.config.main.linking.LinkedAccountConfig;
+import com.discordsrv.common.core.logging.NamedLogger;
 import com.discordsrv.common.events.player.PlayerConnectedEvent;
 import com.discordsrv.common.abstraction.module.AbstractTimedTrackingModule;
 
@@ -31,12 +32,12 @@ import java.util.UUID;
 public class LinkPesteringModule extends AbstractTimedTrackingModule {
 
     public LinkPesteringModule(DiscordSRV discordSRV) {
-        super(discordSRV, "LINK_PESTER");
+        super(discordSRV, new NamedLogger(discordSRV, "LINK_PESTER"));
     }
 
     @Override
     public boolean isEnabled() {
-        return discordSRV.config().linkedAccounts.pesteringConfig.enabled;
+        return discordSRV.config().linkedAccounts.enabled && discordSRV.config().linkedAccounts.pesteringConfig.enabled;
     }
 
     @Subscribe
@@ -53,14 +54,13 @@ public class LinkPesteringModule extends AbstractTimedTrackingModule {
     }
 
     @Override
-    protected Duration getMinimalInterval() {
-        return Duration.ofSeconds(10);
+    protected Duration getMinimumInterval() {
+        return Duration.ofMinutes(1);
     }
 
     @Override
     protected Duration timedTaskInterval() {
-        int intervalSeconds = Math.max(discordSRV.config().linkedAccounts.pesteringConfig.timer, 10);
-        return Duration.ofSeconds(intervalSeconds);
+        return Duration.ofMinutes(discordSRV.config().linkedAccounts.pesteringConfig.timer);
     }
 
     @Override

--- a/common/src/main/java/com/discordsrv/common/helper/VanishStatusTrackingModule.java
+++ b/common/src/main/java/com/discordsrv/common/helper/VanishStatusTrackingModule.java
@@ -20,12 +20,10 @@ package com.discordsrv.common.helper;
 
 import com.discordsrv.api.eventbus.Subscribe;
 import com.discordsrv.api.events.vanish.PlayerVanishStatusChangeEvent;
-import com.discordsrv.api.reload.ReloadResult;
 import com.discordsrv.common.DiscordSRV;
+import com.discordsrv.common.abstraction.module.AbstractTimedTrackingModule;
 import com.discordsrv.common.abstraction.player.IPlayer;
 import com.discordsrv.common.config.main.PluginIntegrationConfig;
-import com.discordsrv.common.core.logging.NamedLogger;
-import com.discordsrv.common.core.module.type.AbstractModule;
 import com.discordsrv.common.events.player.PlayerConnectedEvent;
 import com.discordsrv.common.events.player.PlayerDisconnectedEvent;
 
@@ -35,19 +33,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
-public class VanishStatusTrackingModule extends AbstractModule<DiscordSRV> {
+public class VanishStatusTrackingModule extends AbstractTimedTrackingModule {
 
     private final ThreadLocal<Boolean> localUpdate = ThreadLocal.withInitial(() -> false);
     private final AtomicBoolean receivingVanishEvents = new AtomicBoolean(false);
     private final Map<UUID, Boolean> vanishStatuses = new ConcurrentHashMap<>();
-    private Future<?> vanishUpdateFuture;
 
     public VanishStatusTrackingModule(DiscordSRV discordSRV) {
-        super(discordSRV, new NamedLogger(discordSRV, "VANISH_TRACKER"));
+        super(discordSRV, "VANISH_TRACKER");
     }
 
     @Override
@@ -57,18 +52,14 @@ public class VanishStatusTrackingModule extends AbstractModule<DiscordSRV> {
 
     @Override
     public void enable() {
+        super.enable();
         receivingVanishEvents.set(false);
         updateVanishStatuses();
     }
 
     @Override
-    public void reload(Consumer<ReloadResult> resultConsumer) {
-        startTimedTracking();
-    }
-
-    @Override
     public void disable() {
-        stopTimedTracking();
+        super.disable();
         vanishStatuses.clear();
     }
 
@@ -110,20 +101,20 @@ public class VanishStatusTrackingModule extends AbstractModule<DiscordSRV> {
         }
     }
 
-    private void startTimedTracking() {
-        stopTimedTracking();
-
-        if (useTimedUpdates()) {
-            int seconds = discordSRV.config().integrations.vanishTrackingTimerSeconds;
-            vanishUpdateFuture = discordSRV.scheduler().runAtFixedRate(this::updateVanishStatuses, Duration.ofSeconds(seconds));
-        }
+    @Override
+    protected boolean shouldRunTimedTask() {
+        return useTimedUpdates();
     }
 
-    private void stopTimedTracking() {
-        if (vanishUpdateFuture != null) {
-            vanishUpdateFuture.cancel(true);
-            vanishUpdateFuture = null;
-        }
+    @Override
+    protected Duration timedTaskInterval() {
+        int seconds = discordSRV.config().integrations.vanishTrackingTimerSeconds;
+        return Duration.ofSeconds(seconds);
+    }
+
+    @Override
+    protected void runTimedTask() {
+        updateVanishStatuses();
     }
 
     private void updateVanishStatuses() {

--- a/common/src/main/java/com/discordsrv/common/helper/VanishStatusTrackingModule.java
+++ b/common/src/main/java/com/discordsrv/common/helper/VanishStatusTrackingModule.java
@@ -107,6 +107,11 @@ public class VanishStatusTrackingModule extends AbstractTimedTrackingModule {
     }
 
     @Override
+    protected Duration getMinimalInterval() {
+        return Duration.ofSeconds(1);
+    }
+
+    @Override
     protected Duration timedTaskInterval() {
         int seconds = discordSRV.config().integrations.vanishTrackingTimerSeconds;
         return Duration.ofSeconds(seconds);

--- a/common/src/main/java/com/discordsrv/common/helper/VanishStatusTrackingModule.java
+++ b/common/src/main/java/com/discordsrv/common/helper/VanishStatusTrackingModule.java
@@ -24,6 +24,7 @@ import com.discordsrv.common.DiscordSRV;
 import com.discordsrv.common.abstraction.module.AbstractTimedTrackingModule;
 import com.discordsrv.common.abstraction.player.IPlayer;
 import com.discordsrv.common.config.main.PluginIntegrationConfig;
+import com.discordsrv.common.core.logging.NamedLogger;
 import com.discordsrv.common.events.player.PlayerConnectedEvent;
 import com.discordsrv.common.events.player.PlayerDisconnectedEvent;
 
@@ -42,7 +43,7 @@ public class VanishStatusTrackingModule extends AbstractTimedTrackingModule {
     private final Map<UUID, Boolean> vanishStatuses = new ConcurrentHashMap<>();
 
     public VanishStatusTrackingModule(DiscordSRV discordSRV) {
-        super(discordSRV, "VANISH_TRACKER");
+        super(discordSRV, new NamedLogger(discordSRV,"VANISH_TRACKER"));
     }
 
     @Override
@@ -107,7 +108,7 @@ public class VanishStatusTrackingModule extends AbstractTimedTrackingModule {
     }
 
     @Override
-    protected Duration getMinimalInterval() {
+    protected Duration getMinimumInterval() {
         return Duration.ofSeconds(1);
     }
 

--- a/common/src/main/java/com/discordsrv/common/helper/VanishStatusTrackingModule.java
+++ b/common/src/main/java/com/discordsrv/common/helper/VanishStatusTrackingModule.java
@@ -27,6 +27,7 @@ import com.discordsrv.common.config.main.PluginIntegrationConfig;
 import com.discordsrv.common.core.logging.NamedLogger;
 import com.discordsrv.common.events.player.PlayerConnectedEvent;
 import com.discordsrv.common.events.player.PlayerDisconnectedEvent;
+import org.jspecify.annotations.NonNull;
 
 import java.time.Duration;
 import java.util.HashSet;
@@ -113,7 +114,7 @@ public class VanishStatusTrackingModule extends AbstractTimedTrackingModule {
     }
 
     @Override
-    protected Duration timedTaskInterval() {
+    protected @NonNull Duration timedTaskInterval() {
         int seconds = discordSRV.config().integrations.vanishTrackingTimerSeconds;
         return Duration.ofSeconds(seconds);
     }

--- a/modded/src/main/java/com/discordsrv/modded/mixin/PlayerConnectionEventsMixin.java
+++ b/modded/src/main/java/com/discordsrv/modded/mixin/PlayerConnectionEventsMixin.java
@@ -47,7 +47,7 @@ public class PlayerConnectionEventsMixin {
     private void handlePlayerLeave(ServerPlayer player, CallbackInfo ci) {
         MixinUtils.withClass("com.discordsrv.modded.player.ModdedPlayerProvider")
                 .withInstance()
-                .withMethod("removePlayer", player, false)
+                .withMethod("removePlayer", player)
                 .execute();
     }
 }


### PR DESCRIPTION
Can be configured to be based on a timer, on player connection or both.

Also adds a new prefix for getting the current linking command and fixes an issue on modded, where disconnecting doesn't remove the player.

Closes #52