### PR TITLE
Allow presence updates to be disabled

### DIFF
--- a/common/src/main/java/com/discordsrv/common/config/main/PresenceUpdaterConfig.java
+++ b/common/src/main/java/com/discordsrv/common/config/main/PresenceUpdaterConfig.java
@@ -35,6 +35,9 @@ import java.util.Locale;
 @ConfigSerializable
 public class PresenceUpdaterConfig {
 
+    @Comment("If the bot's Discord presence should be updated")
+    public boolean enabled = true;
+
     @Comment("The number of seconds between presence updates\n"
             + "Minimum value: %1")
     @Constants.Comment("30")

--- a/common/src/main/java/com/discordsrv/common/feature/PresenceUpdaterModule.java
+++ b/common/src/main/java/com/discordsrv/common/feature/PresenceUpdaterModule.java
@@ -51,6 +51,16 @@ public class PresenceUpdaterModule extends AbstractModule<DiscordSRV> {
     }
 
     @Override
+    public boolean isEnabled() {
+        return discordSRV.config() != null && discordSRV.config().presenceUpdater.enabled;
+    }
+
+    @Override
+    public void disable() {
+        cancelFuture();
+    }
+
+    @Override
     public void serverStarted() {
         logger().debug("Server started");
         serverState.set(ServerState.STARTED);
@@ -97,11 +107,16 @@ public class PresenceUpdaterModule extends AbstractModule<DiscordSRV> {
         jda.getPresence().setPresence(config.status, newActivity);
     }
 
-    private void setPresenceOrSchedule() {
-        boolean alreadyScheduled = future != null;
+    private void cancelFuture() {
         if (future != null) {
             future.cancel(true);
+            future = null;
         }
+    }
+
+    private void setPresenceOrSchedule() {
+        boolean alreadyScheduled = future != null;
+        cancelFuture();
 
         if (discordSRV.isServerStarted() && serverState.get() == ServerState.PRE_START) {
             logger().debug("Server is started, changing to STARTED state");


### PR DESCRIPTION
This is a minor change supporting #56, which allows for the config to disable sending presence events to Discord. This allow multiple DiscordSRV connections through the same bot without fighting over presence. Use cases include mutli-server setups or presences controlled by existing external software. 