### PR TITLE
fix: values of the vanish status change event are actually inverted

### DIFF
--- a/bukkit/shared/src/main/java/com/discordsrv/bukkit/integration/EssentialsXIntegration.java
+++ b/bukkit/shared/src/main/java/com/discordsrv/bukkit/integration/EssentialsXIntegration.java
@@ -230,7 +230,7 @@ public class EssentialsXIntegration
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onVanishStatusChange(VanishStatusChangeEvent event) {
-        IUser user = event.getAffected();
+        IUser user = event.getController();
         DiscordSRVPlayer player = discordSRV.playerProvider().player(user.getBase());
 
         discordSRV.eventBus().publish(new PlayerVanishStatusChangeEvent(player, event.getValue(), false, null));

--- a/bukkit/shared/src/main/java/com/discordsrv/bukkit/integration/EssentialsXIntegration.java
+++ b/bukkit/shared/src/main/java/com/discordsrv/bukkit/integration/EssentialsXIntegration.java
@@ -230,6 +230,7 @@ public class EssentialsXIntegration
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onVanishStatusChange(VanishStatusChangeEvent event) {
+        // Essentials has these reversed, see https://github.com/EssentialsX/Essentials/blob/26a54475ad74bbf9b400e55bc8083202f540192c/Essentials/src/main/java/net/ess3/api/events/VanishStatusChangeEvent.java#L12-L14
         IUser user = event.getController();
         DiscordSRVPlayer player = discordSRV.playerProvider().player(user.getBase());
 


### PR DESCRIPTION
Values of the status change event are [inverted](https://github.com/EssentialsX/Essentials/blob/26a54475ad74bbf9b400e55bc8083202f540192c/Essentials/src/main/java/net/ess3/api/events/VanishStatusChangeEvent.java#L12-L14). This means currently the person running the command gets sent to the event instead of the one who's being affected. Currently throws NPEs if console runs the vanish command.

